### PR TITLE
5.2.32 release changes

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -557,7 +557,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Union the collection with the given items.
      *
      * @param  mixed  $items
-     * @return void
+     * @return static
      */
     public function union($items)
     {


### PR DESCRIPTION
The `testCastingToStringJsonEncodesTheToArrayResult` test is still omitted until [this PR](https://github.com/laravel/framework/pull/13593) is merged and released. No other changes were found, and all tests are confirmed to be passing.

- [x] All related collection files copied in
- [x] `helpers.php` manually verified with no changes
- [x] `testCastingToStringJsonEncodesTheToArrayResult` is still omitted
- [x] All tests verified passing 