### PR TITLE
Upgrade PHP version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9"
+        "php": ">=5.6.4"
     },
     "require-dev": {
         "mockery/mockery": "~0.9.4",


### PR DESCRIPTION
Resolves #25. Collection usage of PHP's `array_filter` uses the
optional `flag` parameter, which was added in PHP 5.6.