### PR TITLE
Remove FAQ section about `Illuminate` namespace

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,5 +22,7 @@ composer require tightenco/collect
 ## FAQ
  - **Will this develop independently from Illuminate's Collections?**  
     No. Right now it's split manually, but the goal is for it shortly to be split automatically to keep it in sync with Laravel's Collections, even mirroring the release numbers.
+ - **Why isn't this just under the Illuminate namespace?**  
+    Because that would require adding a lot of complexity and duplication to Illuminate\Support's internal structure. One day Taylor may choose to do that, but right now he hasn't and doesn't have any immediate plans to do so. If he does, we'll deprecate this package and point to the core version.
  - **Why not just use an array?**  
     What a great question. [Tightenite Adam Wathan has a book about that.](http://adamwathan.me/refactoring-to-collections/)

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,5 @@ composer require tightenco/collect
 ## FAQ
  - **Will this develop independently from Illuminate's Collections?**  
     No. Right now it's split manually, but the goal is for it shortly to be split automatically to keep it in sync with Laravel's Collections, even mirroring the release numbers.
- - **Why isn't this just under the Illuminate namespace?**  
-    Because that would require adding a lot of complexity and duplication to Illuminate\Support's internal structure. One day Taylor may choose to do that, but right now he hasn't and doesn't have any immediate plans to do so. If he does, we'll deprecate this package and point to the core version.
  - **Why not just use an array?**  
     What a great question. [Tightenite Adam Wathan has a book about that.](http://adamwathan.me/refactoring-to-collections/)

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,8 @@ composer require tightenco/collect
 ## FAQ
  - **Will this develop independently from Illuminate's Collections?**  
     No. Right now it's split manually, but the goal is for it shortly to be split automatically to keep it in sync with Laravel's Collections, even mirroring the release numbers.
- - **Why isn't this just under the Illuminate namespace?**  
-    Because that would require adding a lot of complexity and duplication to Illuminate\Support's internal structure. One day Taylor may choose to do that, but right now he hasn't and doesn't have any immediate plans to do so. If he does, we'll deprecate this package and point to the core version.
+ - **Why isn't the package named illuminate/collect?**  
+    It's not an official Laravel package so we don't want to use the namespace reserved by Laravel packages.  
+    One day `Collection` may be extracted from `illuminate/support` to a new package. If so, we'll deprecate this package and point to the core version.
  - **Why not just use an array?**  
     What a great question. [Tightenite Adam Wathan has a book about that.](http://adamwathan.me/refactoring-to-collections/)


### PR DESCRIPTION
I'm looking at README which says that package is not using `Illuminate` namespace. Then I look into code and see that, in fact, it is using it :)
It's bit of confusing so maybe let's just remove it?