### PR TITLE
Downgrade php syntax to support php version 5.6.

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -290,7 +290,7 @@ class Arr
         }
 
         if (strpos($key, '.') === false) {
-            return $array[$key] ?? value($default);
+            return $array[$key] ? $array[$key] : value($default);
         }
 
         foreach (explode('.', $key) as $segment) {

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -151,8 +151,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return;
         }
 
-        $values = (isset($key) ? $this->pluck($key) : $this)
-                    ->sort()->values();
+        $values = isset($key) ? $this->pluck($key) : $this->sort()->values();
 
         $middle = (int) ($count / 2);
 


### PR DESCRIPTION
Great Laravel tool named valet can't be started on php verson 5.6 without this fix.