### PR TITLE
Remove relative path to phpunit in scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "scripts": {
         "test": [
             "@composer install",
-            "vendor/bin/phpunit"
+            "phpunit"
         ]
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Adding the vendor/bin prefix is unnecessary in the scripts section as Composer will automatically prefer Composer-installed binaries over system ones.

See https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands

This actually makes the script identical to the example from Composer's docs here: https://getcomposer.org/doc/articles/scripts.md#calling-composer-commands

Technically, it doesn't really make a difference in this case, but it's more of a best practice I think.