### PR TITLE
composer var-dumper ~4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/var-dumper": "~4.0",
+        "symfony/var-dumper": "~4.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/var-dumper": "^3.1.10"
+        "symfony/var-dumper": "~4.0",
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
I faced a conflicts of var-dumper package.  
Official packages has been updated packages but this repo require older version "symfony/var-dumper": "^3.1.10".

illuminate/support suggest var-dumper version `^4.1`  
https://github.com/illuminate/support/blob/master/composer.json#L43  
`"symfony/var-dumper": "Required to use the dd function (^4.1)."`

laravel/framework requiire var-dumper `~4.0`  
https://github.com/laravel/framework/blob/5.6/composer.json#L38  
`"symfony/var-dumper": "~4.0",`