### PR TITLE
allow symfony/var-dumper versions down to 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/var-dumper": "^4.1"
+        "symfony/var-dumper": ">=3.4,<5"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "385a6896e5fc164d5f6b6235b204c267",
+    "content-hash": "deda45106e0583574a16d00ed0c0f73b",
     "packages": [
         {
             "name": "symfony/polyfill-mbstring",
@@ -1036,16 +1036,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.3.4",
+            "version": "7.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0356331bf62896dc56e3a15030b23b73f38b2935"
+                "reference": "7b331efabbb628c518c408fdfcaf571156775de2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0356331bf62896dc56e3a15030b23b73f38b2935",
-                "reference": "0356331bf62896dc56e3a15030b23b73f38b2935",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7b331efabbb628c518c408fdfcaf571156775de2",
+                "reference": "7b331efabbb628c518c408fdfcaf571156775de2",
                 "shasum": ""
             },
             "require": {
@@ -1116,7 +1116,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-09-05T09:58:53+00:00"
+            "time": "2018-09-08T15:14:29+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",


### PR DESCRIPTION
Given that the purpose of this package is to decouple Laravel collections from the rest of Laravel so they can be used in other contexts, would it be OK to allow a superset of versions for `symfony/var-dumper` so that projects using Symfony 3.4 LTS (supported until late 2020) can use latest versions? This PR doesn't increase the maximal constraint on the package, but reduces the minimum constraint to 3.4, to allow use with the full stack Symfony framework at that version.

In the specific case of this package, the only method that is called is (unsurprisingly) `\Symfony\Component\VarDumper\VarDumper::dump()`, and the API for that method hasn't changed in any Symfony 2+ version, neither is it expected to change. So I hope you'd agree this increases interoperability without risking a break.