### PR TITLE
Laravel 5.7.10 changes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -786,16 +786,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.0.8",
+            "version": "6.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "848f78b3309780fef7ec8c4666b7ab4e6b09b22f"
+                "reference": "4d3ae9b21a7d7e440bd0cf65565533117976859f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/848f78b3309780fef7ec8c4666b7ab4e6b09b22f",
-                "reference": "848f78b3309780fef7ec8c4666b7ab4e6b09b22f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4d3ae9b21a7d7e440bd0cf65565533117976859f",
+                "reference": "4d3ae9b21a7d7e440bd0cf65565533117976859f",
                 "shasum": ""
             },
             "require": {
@@ -806,7 +806,7 @@
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-token-stream": "^3.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1",
+                "sebastian/environment": "^3.1 || ^4.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
@@ -819,7 +819,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
@@ -845,7 +845,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-04T03:41:23+00:00"
+            "time": "2018-10-23T05:59:32+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1038,16 +1038,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.4.0",
+            "version": "7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f3837fa1e07758057ae06e8ddec6d06ba183f126"
+                "reference": "c151651fb6ed264038d486ea262e243af72e5e64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f3837fa1e07758057ae06e8ddec6d06ba183f126",
-                "reference": "f3837fa1e07758057ae06e8ddec6d06ba183f126",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c151651fb6ed264038d486ea262e243af72e5e64",
+                "reference": "c151651fb6ed264038d486ea262e243af72e5e64",
                 "shasum": ""
             },
             "require": {
@@ -1068,7 +1068,7 @@
                 "phpunit/php-timer": "^2.0",
                 "sebastian/comparator": "^3.0",
                 "sebastian/diff": "^3.0",
-                "sebastian/environment": "^3.1",
+                "sebastian/environment": "^3.1 || ^4.0",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^2.0",
                 "sebastian/object-enumerator": "^3.0.3",
@@ -1118,7 +1118,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-05T04:05:24+00:00"
+            "time": "2018-10-23T05:57:41+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Written by Taylor Otwell as a part of Laravel's [Illuminate/Support](https://git
 
 Lovingly split by Matt Stauffer for [Tighten Co.](https://tighten.co/), with a kick in the butt to finally do it from [@assertchris](https://github.com/assertchris).
 
-## Installation
+## Install
 
 With [Composer](https://getcomposer.org):
 
@@ -18,13 +18,24 @@ With [Composer](https://getcomposer.org):
 composer require tightenco/collect
 ```
 
+## Upgrade
+To upgrade Collect, simply run `./upgrade.sh` from the root directory. This will pull in the recent Laravel changes, update the Collect package and run the unit tests.
+
+> The upgrade script requires the use of `wget`. To install [homebrew](https://brew.sh), and run `brew install wget`
+
+## Test
+**Currently tests need to be ran after `./upgrade.sh`.**
+
+```bash
+vendor/bin/phpunit
+```
 
 ## FAQ
- - **Will this develop independently from Illuminate's Collections?**  
+ - **Will this develop independently from Illuminate's Collections?**
     No. Right now it's split manually, but the goal is for it shortly to be split automatically to keep it in sync with Laravel's Collections, even mirroring the release numbers.
- - **Why is the package `tightenco/collect` instead of `illuminate/collect`?**  
+ - **Why is the package `tightenco/collect` instead of `illuminate/collect`?**
     It's not an official Laravel package so we don't want to use the Packagist namespace reserved by Laravel packages. One day `Collection` may be extracted from `illuminate/support` to a new package. If so, we'll deprecate this package and point to the core version.
- - **Why not just use an array?**  
+ - **Why not just use an array?**
     What a great question. [Tighten alum Adam Wathan has a book about that.](https://adamwathan.me/refactoring-to-collections/)
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,9 @@ composer require tightenco/collect
 ```
 
 ## Upgrade
-To upgrade Collect, simply run `./upgrade.sh` from the root directory. By default this will pull in the most recent Laravel 5.7 changes, update the Collect package and run the unit tests. The upgrade script accepts a Laravel version, so a specific version can be passed in.
+If you are a developer working on Collect and you're tasked with upgrading it to mirror a new version of Laravel,  run `./upgrade.sh` from the root directory. You can pass a parameter to target a specific Laravel version (e.g. `./upgrade.sh 5.7.10`) or, if you don't pass a parameter, the script will find the latest tagged release and run against that.
+
+The upgrader will pull down the appropriate source and test files for the specified version of Laravel and then run the tests.
 
 ```bash
 ./upgrade.sh

--- a/readme.md
+++ b/readme.md
@@ -19,9 +19,14 @@ composer require tightenco/collect
 ```
 
 ## Upgrade
-To upgrade Collect, simply run `./upgrade.sh` from the root directory. This will pull in the recent Laravel changes, update the Collect package and run the unit tests.
+To upgrade Collect, simply run `./upgrade.sh` from the root directory. By default this will pull in the most recent Laravel 5.7 changes, update the Collect package and run the unit tests. The upgrade script accepts a Laravel version, so a specific version can be passed in.
 
-> The upgrade script requires the use of `wget`. To install [homebrew](https://brew.sh), and run `brew install wget`
+```bash
+./updrade.sh 5.7.10
+```
+
+
+> The upgrade script requires the use of `wget`. It's recommended to install [homebrew](https://brew.sh), and run `brew install wget`
 
 ## Test
 **Due to a [dependency on Carbon](https://github.com/tightenco/collect/commit/4afe1fcb40f1c10e399730562c2c7ca36c6fba01), tests won't pass until you've run `./upgrade.sh` at least once locally.**

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ To upgrade Collect, simply run `./upgrade.sh` from the root directory. This will
 > The upgrade script requires the use of `wget`. To install [homebrew](https://brew.sh), and run `brew install wget`
 
 ## Test
-**Currently tests need to be ran after `./upgrade.sh`.**
+**Due to a [dependency on Carbon](https://github.com/tightenco/collect/commit/4afe1fcb40f1c10e399730562c2c7ca36c6fba01), tests need to be ran after `./upgrade.sh`.**
 
 ```bash
 vendor/bin/phpunit

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,9 @@ composer require tightenco/collect
 To upgrade Collect, simply run `./upgrade.sh` from the root directory. By default this will pull in the most recent Laravel 5.7 changes, update the Collect package and run the unit tests. The upgrade script accepts a Laravel version, so a specific version can be passed in.
 
 ```bash
-./updrade.sh 5.7.10
+./upgrade.sh
+# or
+./upgrade.sh 5.7.10
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Written by Taylor Otwell as a part of Laravel's [Illuminate/Support](https://git
 
 Lovingly split by Matt Stauffer for [Tighten Co.](https://tighten.co/), with a kick in the butt to finally do it from [@assertchris](https://github.com/assertchris).
 
-## Install
+## Installation
 
 With [Composer](https://getcomposer.org):
 
@@ -18,7 +18,7 @@ With [Composer](https://getcomposer.org):
 composer require tightenco/collect
 ```
 
-## Upgrade
+## Development
 If you are a developer working on Collect and you're tasked with upgrading it to mirror a new version of Laravel,  run `./upgrade.sh` from the root directory. You can pass a parameter to target a specific Laravel version (e.g. `./upgrade.sh 5.7.10`) or, if you don't pass a parameter, the script will find the latest tagged release and run against that.
 
 The upgrader will pull down the appropriate source and test files for the specified version of Laravel and then run the tests.
@@ -29,10 +29,9 @@ The upgrader will pull down the appropriate source and test files for the specif
 ./upgrade.sh 5.7.10
 ```
 
-
 > The upgrade script requires the use of `wget`. It's recommended to install [homebrew](https://brew.sh), and run `brew install wget`
 
-## Test
+## Testing
 **Due to a [dependency on Carbon](https://github.com/tightenco/collect/commit/4afe1fcb40f1c10e399730562c2c7ca36c6fba01), tests won't pass until you've run `./upgrade.sh` at least once locally.**
 
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -31,11 +31,11 @@ vendor/bin/phpunit
 ```
 
 ## FAQ
- - **Will this develop independently from Illuminate's Collections?**
+ - **Will this develop independently from Illuminate's Collections?**  
     No. Right now it's split manually, but the goal is for it shortly to be split automatically to keep it in sync with Laravel's Collections, even mirroring the release numbers.
- - **Why is the package `tightenco/collect` instead of `illuminate/collect`?**
+ - **Why is the package `tightenco/collect` instead of `illuminate/collect`?**  
     It's not an official Laravel package so we don't want to use the Packagist namespace reserved by Laravel packages. One day `Collection` may be extracted from `illuminate/support` to a new package. If so, we'll deprecate this package and point to the core version.
- - **Why not just use an array?**
+ - **Why not just use an array?**  
     What a great question. [Tighten alum Adam Wathan has a book about that.](https://adamwathan.me/refactoring-to-collections/)
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ To upgrade Collect, simply run `./upgrade.sh` from the root directory. This will
 > The upgrade script requires the use of `wget`. To install [homebrew](https://brew.sh), and run `brew install wget`
 
 ## Test
-**Due to a [dependency on Carbon](https://github.com/tightenco/collect/commit/4afe1fcb40f1c10e399730562c2c7ca36c6fba01), tests need to be ran after `./upgrade.sh`.**
+**Due to a [dependency on Carbon](https://github.com/tightenco/collect/commit/4afe1fcb40f1c10e399730562c2c7ca36c6fba01), tests won't pass until you've run `./upgrade.sh` at least once locally.**
 
 ```bash
 vendor/bin/phpunit

--- a/src/Collect/Support/Arr.php
+++ b/src/Collect/Support/Arr.php
@@ -629,6 +629,6 @@ class Arr
             return [];
         }
 
-        return ! is_array($value) ? [$value] : $value;
+        return is_array($value) ? $value : [$value];
     }
 }

--- a/src/Collect/Support/Collection.php
+++ b/src/Collect/Support/Collection.php
@@ -172,7 +172,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the median of a given key.
      *
-     * @param  null $key
+     * @param  string|array|null $key
      * @return mixed
      */
     public function median($key = null)
@@ -202,12 +202,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the mode of a given key.
      *
-     * @param  mixed  $key
+     * @param  string|array|null  $key
      * @return array|null
      */
     public function mode($key = null)
     {
-        if ($this->count() == 0) {
+        if ($this->count() === 0) {
             return;
         }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -158,7 +158,7 @@ class SupportArrTest extends TestCase
     {
         // Flat arrays are unaffected
         $array = ['#foo', '#bar', '#baz'];
-        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten(['#foo', '#bar', '#baz']));
+        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten($array));
 
         // Nested arrays are flattened with existing flat items
         $array = [['#foo', '#bar'], '#baz'];

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5,6 +5,7 @@ namespace Tightenco\Collect\Tests\Support;
 use stdClass;
 use Exception;
 use ArrayAccess;
+use ArrayObject;
 use Mockery as m;
 use ArrayIterator;
 use CachingIterator;
@@ -1164,7 +1165,7 @@ class SupportCollectionTest extends TestCase
 
     public function testRandomOnEmptyCollection()
     {
-        $data = new Collection();
+        $data = new Collection;
 
         $random = $data->random(0);
         $this->assertInstanceOf(Collection::class, $random);
@@ -2389,13 +2390,13 @@ class SupportCollectionTest extends TestCase
 
     public function testCollectionFromTraversable()
     {
-        $collection = new Collection(new \ArrayObject([1, 2, 3]));
+        $collection = new Collection(new ArrayObject([1, 2, 3]));
         $this->assertEquals([1, 2, 3], $collection->toArray());
     }
 
     public function testCollectionFromTraversableWithKeys()
     {
-        $collection = new Collection(new \ArrayObject(['foo' => 1, 'bar' => 2, 'baz' => 3]));
+        $collection = new Collection(new ArrayObject(['foo' => 1, 'bar' => 2, 'baz' => 3]));
         $this->assertEquals(['foo' => 1, 'bar' => 2, 'baz' => 3], $collection->toArray());
     }
 
@@ -2735,7 +2736,7 @@ class SupportCollectionTest extends TestCase
 
     public function testPutAddsItemToCollection()
     {
-        $collection = new Collection();
+        $collection = new Collection;
         $this->assertSame([], $collection->toArray());
         $collection->put('foo', 1);
         $this->assertSame(['foo' => 1], $collection->toArray());
@@ -2747,7 +2748,7 @@ class SupportCollectionTest extends TestCase
 
     public function testItThrowsExceptionWhenTryingToAccessNoProxyProperty()
     {
-        $collection = new Collection();
+        $collection = new Collection;
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Property [foo] does not exist on this collection instance.');
         $collection->foo;


### PR DESCRIPTION
This pulls in Laravel [5.7.10 changes](https://github.com/laravel/framework/releases/tag/v5.7.10), and updates the readme.