### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto eol=lf
+
+/stubs export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/collect-logo.png export-ignore
+/.travis.yml export-ignore
+/phpunit.xml export-ignore
+/readme.md export-ignore
+/upgrade.sh export-ignore


### PR DESCRIPTION
This way the users of this package doesn't have to download [non-essential files which aren't necessary](https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/) for the package to function. Such as files used for development (docs, screenshots, tests, .travis.yml, etc). This will reduce the package size from 264 KB to 85KB in production.

[Example from `laravel/framework`.](https://github.com/laravel/framework/blob/3fb0d75a97529e394002c9ac641c95ceae79b9da/.gitattributes#L3-L14)