### PR TITLE
Laravel 5.8.17 changes

### DIFF
--- a/src/Collect/Support/Collection.php
+++ b/src/Collect/Support/Collection.php
@@ -1854,7 +1854,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get a value retrieving callback.
      *
-     * @param  string  $value
+     * @param  callable|string|null  $value
      * @return callable
      */
     protected function valueRetriever($value)


### PR DESCRIPTION
1. `valueRetriever()` now accepts `callable` and `null` values