### PR TITLE
Remove dd helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
-        "symfony/var-dumper": ">=3.4 <5"
+        "php": "^7.1.3"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/src/Collect/Support/helpers.php
+++ b/src/Collect/Support/helpers.php
@@ -2,7 +2,6 @@
 
 use Tightenco\Collect\Support\Arr;
 use Tightenco\Collect\Support\Collection;
-use Tightenco\Collect\Support\Debug\Dumper;
 
 if (! class_exists(Illuminate\Support\Collection::class)) {
     if (! function_exists('array_wrap')) {
@@ -97,22 +96,6 @@ if (! class_exists(Illuminate\Support\Collection::class)) {
         function with($object)
         {
             return $object;
-        }
-    }
-
-    if (! function_exists('dd')) {
-        /**
-         * Dump the passed variables and end the script.
-         *
-         * @param  mixed
-         * @return void
-         */
-        function dd(...$args)
-        {
-            foreach ($args as $x) {
-                (new Dumper)->dump($x);
-            }
-            die(1);
         }
     }
 }


### PR DESCRIPTION
Dumper classes were all removed from this package but the helper definition was missed.

Fixes issue #154, #168 