### PR TITLE
Require symfony/var-dumper, add dd() helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": "^7.1.3"
+        "php": "^7.1.3",
+        "symfony/var-dumper": ">=3.4 <5"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/src/Collect/Support/helpers.php
+++ b/src/Collect/Support/helpers.php
@@ -2,6 +2,7 @@
 
 use Tightenco\Collect\Support\Arr;
 use Tightenco\Collect\Support\Collection;
+use Symfony\Component\VarDumper\VarDumper;
 
 if (! class_exists(Illuminate\Support\Collection::class)) {
     if (! function_exists('array_wrap')) {
@@ -96,6 +97,22 @@ if (! class_exists(Illuminate\Support\Collection::class)) {
         function with($object)
         {
             return $object;
+        }
+    }
+
+    if (! function_exists('dd')) {
+        /**
+         * Dump the passed variables and end the script.
+         *
+         * @param  mixed
+         * @return void
+         */
+        function dd(...$args)
+        {
+            foreach ($args as $x) {
+               VarDumper::dump($x);
+            }
+            die(1);
         }
     }
 }

--- a/stubs/src/Collect/Support/helpers.php
+++ b/stubs/src/Collect/Support/helpers.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Debug\Dumper;
+use Symfony\Component\VarDumper\VarDumper;
 
 if (! class_exists(/*--- OLDNAMESPACE ---*/\Support\Collection::class)) {
     if (! function_exists('array_wrap')) {
@@ -110,7 +110,7 @@ if (! class_exists(/*--- OLDNAMESPACE ---*/\Support\Collection::class)) {
         function dd(...$args)
         {
             foreach ($args as $x) {
-                (new Dumper)->dump($x);
+               VarDumper::dump($x);
             }
             die(1);
         }


### PR DESCRIPTION
This pull request adds the `symfony/var-dumper` library that was removed. Additionally, it adds the `dd()` helper which now uses `VarDumper::dump()` method instead of `Dumper`.