### PR TITLE
Remove dd() helper function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/var-dumper": ">=3.4 <5"
+        "symfony/var-dumper": "^4.2 || ^5.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/src/Collect/Support/helpers.php
+++ b/src/Collect/Support/helpers.php
@@ -99,20 +99,4 @@ if (! class_exists(Illuminate\Support\Collection::class)) {
             return $object;
         }
     }
-
-    if (! function_exists('dd')) {
-        /**
-         * Dump the passed variables and end the script.
-         *
-         * @param  mixed
-         * @return void
-         */
-        function dd(...$args)
-        {
-            foreach ($args as $x) {
-               VarDumper::dump($x);
-            }
-            die(1);
-        }
-    }
 }


### PR DESCRIPTION
The `dd()` [function was added](https://github.com/symfony/var-dumper/blob/f2cd3f043b3e828015340d0d3cd0ca7daba038c2/Resources/functions/dump.php#L34-L43) to `symfony/var-dumper` by popular demand (probably because of Laravel). This pull request also adds Symfony 5 support since it is due to be released this month.