### PR TITLE
Test against future PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
   - nightly
 
 matrix:


### PR DESCRIPTION
Since nightly is PHP 8, it could nice to test against PHP 7.4 too, as it will be launched in a few weeks, and prepared for it, spotting anything to be done in case tests doesn't pass.