### PR TITLE
Add Symfony 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/var-dumper": ">=3.4 <5"
+        "symfony/var-dumper": "^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
This pull request adds Symfony 5 support. First beta version of Symfony 5 was released just yesterday.

This is a follow up PR from #191.