### PR TITLE
Fix typehint countBy

### DIFF
--- a/src/Collect/Support/Traits/EnumeratesValues.php
+++ b/src/Collect/Support/Traits/EnumeratesValues.php
@@ -807,20 +807,20 @@ trait EnumeratesValues
     }
 
     /**
-     * Count the number of items in the collection using a given truth test.
+     * Count the number of items in the collection by a field or using a callback.
      *
-     * @param  callable|null  $callback
+     * @param  array|callable|string $countBy
      * @return static
      */
-    public function countBy($callback = null)
+    public function countBy($countBy = null)
     {
-        if (is_null($callback)) {
-            $callback = function ($value) {
+        if (is_null($countBy)) {
+            $countBy = function ($value) {
                 return $value;
             };
         }
 
-        return new static($this->groupBy($callback)->map(function ($value) {
+        return new static($this->groupBy($countBy)->map(function ($value) {
             return $value->count();
         }));
     }


### PR DESCRIPTION
This function call `groupBy` which accept `array|callable|string` so this one must accept as well.