### PR TITLE
Add Laravel 8 to supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
   - nightly
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - 8.0
   - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "symfony/var-dumper": "^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 8 supports PHP 8.
Currently the highest version compatible with php 8.0 is recognized as 5.6.

## Reference
[PHP 8.0.0 Released!](https://www.php.net/archive/2020.php#2020-11-26-3)
[Laravel 8.x Collection comoser.json](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Collections/composer.json)