### PR TITLE
Replace Travis CI with GitHub Action badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![Travis Status for tightenco/collect](https://travis-ci.org/tightenco/collect.svg?branch=laravel-6-ongoing)](https://travis-ci.org/tightenco/collect)
+![Run tests](https://github.com/tighten/collect/workflows/Run%20tests/badge.svg)
 
 ![](https://raw.githubusercontent.com/tighten/collect/master/collect-logo.png)
 
@@ -41,11 +41,11 @@ vendor/bin/phpunit
 ```
 
 ## FAQ
- - **Has this ever, or will it ever, develop independently from Illuminate's Collections?**  
+ - **Has this ever, or will it ever, develop independently from Illuminate's Collections?**
     No. Using an upgrade script, it's split automatically with every Laravel release to keep it in sync with Laravel's Collections, even mirroring the release numbers.
- - **Why is the package `tightenco/collect` instead of `illuminate/collect`?**  
+ - **Why is the package `tightenco/collect` instead of `illuminate/collect`?**
     It's not an official Laravel package so we don't want to use the Packagist namespace reserved by Laravel packages. ~One day `Collection` may be extracted from `illuminate/support` to a new package. If so, we'll deprecate this package and point to the core version.~ Now that `illuminate/collections` has been released, we're deprecating this package.
- - **Why not just use an array?**  
+ - **Why not just use an array?**
     What a great question. [Tighten alum Adam Wathan has a book about that.](https://adamwathan.me/refactoring-to-collections/)
 
 ## License


### PR DESCRIPTION
# Changed log

- Removing unused white spaces on `readme` file.
- Replace Travis CI with GitHub Action badge.