### PR TITLE
Symfony v6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "symfony/var-dumper": "^3.4 || ^4.0 || ^5.0"
+        "symfony/var-dumper": "^3.4 || ^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
~We'll need this for Jetstream (I think?)~

We didn't end up needing this for Jetstream but since Symfony v6 is out now, can't hurt to support it 🙂 